### PR TITLE
Fix min coverage variation region detection

### DIFF
--- a/ProGenFixer.c
+++ b/ProGenFixer.c
@@ -523,6 +523,7 @@ typedef struct { // data structure for file evaluation
     int max_assem_cov; // Added max assembly coverage
 
     uint64_t *kms;
+    int kms_count;
     int k;
     int p;
     var_location *var_locs;
@@ -1170,6 +1171,10 @@ int extent_var_loc(evaluation_t *eva, uint64_t *kms, var_location *var_loc, int 
         fprintf(stderr, "Error: Invalid parameters\n");
         return 0;
     }
+    if (eva->kms_count <= 0) {
+        fprintf(stderr, "Error: Invalid k-mer array size\n");
+        return 0;
+    }
     
     int k = eva->k;
     uint64_t mask = (1ULL<<k*2) - 1;
@@ -1189,8 +1194,9 @@ int extent_var_loc(evaluation_t *eva, uint64_t *kms, var_location *var_loc, int 
     }
     
     var_loc->pos_t = var_loc->pos_t + dis;
-    // We don't know the upper bound without knowing the size of kms array
-    // So we'll rely on the cov check to prevent going too far
+    if (var_loc->pos_t >= eva->kms_count) {
+        var_loc->pos_t = eva->kms_count - 1;
+    }
     
     int cov_s = kmer_cov(min_hash_key(kms[var_loc->pos_s], k), mask, eva->h);
     int cov_t = kmer_cov(min_hash_key(kms[var_loc->pos_t], k), mask, eva->h);
@@ -1209,7 +1215,7 @@ int extent_var_loc(evaluation_t *eva, uint64_t *kms, var_location *var_loc, int 
     itt = 0;
     // We need to limit how far we can extend to avoid going out of bounds
     int max_extension = MAX_EXTENT_DISTANCE;
-    while (cov_t <= assem_min_cov && itt < dis && itt < max_extension) {
+    while (cov_t <= assem_min_cov && itt < dis && itt < max_extension && var_loc->pos_t < eva->kms_count - 1) {
         var_loc->pos_t = var_loc->pos_t + 1;
         cov_t = kmer_cov(min_hash_key(kms[var_loc->pos_t], k), mask, eva->h);
         itt = itt + 1;
@@ -1265,6 +1271,39 @@ int optimize_var_loc(evaluation_t *eva, uint64_t *kms, var_location *var_loc, in
     return 1;
 } 
 
+static int append_var_location(evaluation_t *eva, var_location *var_locs, int *var_loc_num,
+                               int var_loc_capacity, uint64_t *kms, int pos_s, int pos_t,
+                               int term_cov, uint64_t mask, const char *seq_name)
+{
+    int k = eva->k;
+
+    if (pos_s < 0 || pos_t <= pos_s || pos_t >= eva->kms_count) return 0;
+    if (pos_t - pos_s <= k) return 0;
+
+    if (*var_loc_num >= var_loc_capacity) {
+        fprintf(stderr, "Warning: variation-location buffer is full; skipping remaining locations\n");
+        return -1;
+    }
+
+    int rep_km_num = kmer_cov(min_hash_key(kms[pos_t], k), mask, eva->hr);
+    int s_km_cov = kmer_cov(min_hash_key(kms[pos_s], k), mask, eva->h);
+
+    if (rep_km_num >= MAX_REP_KM_NUM) return 0;
+    if (term_cov <= 0 || (long long)s_km_cov > (long long)term_cov * MAX_COV_RATIO) return 0;
+
+    var_location *loc = &var_locs[*var_loc_num];
+    loc->kmer_s = kms[pos_s];
+    loc->pos_s = pos_s;
+    loc->kmer_t = kms[pos_t];
+    loc->pos_t = pos_t;
+
+    strncpy(loc->name, seq_name, sizeof(loc->name) - 1);
+    loc->name[sizeof(loc->name) - 1] = '\0';
+
+    (*var_loc_num)++;
+    return 1;
+}
+
 // Search for locations with variations
 static evaluation_t *analysis_ref_seq(evaluation_t *eva, const char *fn, int max_len, int min_cov, int assem_min_cov)
 {
@@ -1297,50 +1336,48 @@ static evaluation_t *analysis_ref_seq(evaluation_t *eva, const char *fn, int max
         // Allocate memory for this sequence
         MALLOC(kms, l); 
         km_num = seq_kmers(kms, k, l, pl.ks->seq.s);
+        eva->kms = kms;
+        eva->kms_count = km_num;
         
         MALLOC(var_locs, (l-k + 1));
         
         // Reset variation locations counter for this sequence
         int var_loc_num = 0;
-        var_location one_var_loc;
-        one_var_loc.kmer_s = 0;
-        one_var_loc.pos_s = -1;
+        int last_anchor_pos = -1;
+        int open_var_pos_s = -1;
+        int in_low_cov_run = 0;
+        int low_cov_kmers = 0;
+        // -c opens low-coverage candidates; -a closes them with assembly-usable anchors.
+        int anchor_min_cov = assem_min_cov > 0 ? assem_min_cov : min_cov;
         
         // Find variation locations for this sequence
         int j = 0;
         while(j < km_num) {
             int cov = kmer_cov(min_hash_key(kms[j],k), mask, eva->h);
-            
-            if(cov < min_cov) { // k-mer NOT present 
-                if(one_var_loc.pos_s < 0 && j > k) {
-                    one_var_loc.kmer_s = kms[j-1];
-                    one_var_loc.pos_s = j - 1;
-                }
-            } else { // k-mer present
-                if(one_var_loc.pos_s > 0) {
-                    int rep_km_num = kmer_cov(min_hash_key(kms[j],k), mask, eva->hr); 
-                    int s_km_cov = kmer_cov(min_hash_key(one_var_loc.kmer_s,k), mask, eva->h);
-                    
-                    if(rep_km_num < MAX_REP_KM_NUM && (cov > 0 && s_km_cov/cov <= MAX_COV_RATIO)) {
-                        var_locs[var_loc_num].kmer_s = one_var_loc.kmer_s;
-                        var_locs[var_loc_num].pos_s = one_var_loc.pos_s;
-                        var_locs[var_loc_num].kmer_t = kms[j];
-                        var_locs[var_loc_num].pos_t = j;
-                        
-                        strncpy(var_locs[var_loc_num].name, pl.ks->name.s, sizeof(var_locs[var_loc_num].name)-1);
-                        var_locs[var_loc_num].name[sizeof(var_locs[var_loc_num].name)-1] = '\0';
-                        
-                        if(var_locs[var_loc_num].pos_t - var_locs[var_loc_num].pos_s <= k) {
-                            var_locs[var_loc_num].pos_t = var_locs[var_loc_num].pos_s + k + 1;
-                            var_locs[var_loc_num].kmer_t = kms[var_locs[var_loc_num].pos_t];
-                        }
-                        
-                        one_var_loc.kmer_s = 0;
-                        one_var_loc.pos_s = -1;
-                        var_loc_num++;
-                    }
+            int is_low_cov = cov < min_cov;
+            int is_anchor = cov >= anchor_min_cov;
+            int starts_low_cov_run = is_low_cov && !in_low_cov_run;
+
+            if (is_low_cov) low_cov_kmers++;
+
+            if (open_var_pos_s >= 0 && is_anchor) {
+                int added = append_var_location(eva, var_locs, &var_loc_num, km_num, kms,
+                                                open_var_pos_s, j, cov, mask, pl.ks->name.s);
+                if (added < 0) break;
+                if (added > 0) {
+                    open_var_pos_s = -1;
+                    last_anchor_pos = j;
                 }
             }
+
+            if (open_var_pos_s < 0) {
+                if (starts_low_cov_run && last_anchor_pos >= 0 && last_anchor_pos < j && j > k) {
+                    open_var_pos_s = last_anchor_pos;
+                } else if (is_anchor) {
+                    last_anchor_pos = j;
+                }
+            }
+            in_low_cov_run = is_low_cov;
             j++;
         }
         
@@ -1348,7 +1385,9 @@ static evaluation_t *analysis_ref_seq(evaluation_t *eva, const char *fn, int max
         eva->var_locs = var_locs;
         eva->kms = kms;
         
-        fprintf(stderr, "Found %d variation locations in sequence: %s\n", var_loc_num, pl.ks->name.s);
+        fprintf(stderr,
+                "Found %d variation locations in sequence: %s (low-coverage k-mers: %d, region min: %d, anchor min: %d)\n",
+                var_loc_num, pl.ks->name.s, low_cov_kmers, min_cov, anchor_min_cov);
         
 
 
@@ -1365,6 +1404,7 @@ static evaluation_t *analysis_ref_seq(evaluation_t *eva, const char *fn, int max
         free(kms);
         free(var_locs);
         eva->kms = NULL;
+        eva->kms_count = 0;
         eva->var_locs = NULL;
     }
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Where:
 ### Options
 
 - `-k INT` : k-mer size (default: 31)
-- `-c INT` : minimal k-mer coverage for detection of variation regions (default: 2)
-- `-a INT` : minimal k-mer coverage for variant calling (default: 5)
+- `-c INT` : minimal reference k-mer coverage that opens a candidate variation region (default: 2)
+- `-a INT` : minimal k-mer coverage for variant calling and region-closing anchors (default: 5)
 - `-m INT` : maximal k-mer coverage for assemble-based variant calling [0, 0=no limit]
 - `-l INT` : maximal assembly length for variant calling (default: 1000)
 - `-t INT` : number of threads for k-mer counting (default: 3)

--- a/tests/test_min_cov_region_detection.sh
+++ b/tests/test_min_cov_region_detection.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/progenfixer-mincov.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+python3 - "$tmpdir" <<'PY'
+import random
+import sys
+from pathlib import Path
+
+out = Path(sys.argv[1])
+k = 5
+random.seed(7)
+comp = str.maketrans("ACGT", "TGCA")
+
+def canonical(seq):
+    rc = seq.translate(comp)[::-1]
+    return min(seq, rc)
+
+seq = "".join(random.choice("ACGT") for _ in range(k))
+seen = {canonical(seq)}
+while len(seq) < 80:
+    choices = []
+    for base in "ACGT":
+        mer = seq[-(k - 1):] + base
+        can = canonical(mer)
+        if can not in seen:
+            choices.append((base, can))
+    if not choices:
+        raise RuntimeError("failed to build unique reference sequence")
+    base, can = random.choice(choices)
+    seq += base
+    seen.add(can)
+
+kmers = [seq[i:i + k] for i in range(len(seq) - k + 1)]
+coverage = [5] * len(kmers)
+
+# Two true low-coverage blocks separated by weak coverage. The weak middle
+# block must not become an artificial region boundary when -c is low.
+for i in range(20, 26):
+    coverage[i] = 1
+for i in range(26, 32):
+    coverage[i] = 3
+for i in range(32, 38):
+    coverage[i] = 1
+
+# A separate weak block should become a candidate only when -c is high enough.
+for i in range(45, 51):
+    coverage[i] = 3
+
+(out / "ref.fa").write_text(">ref\n" + seq + "\n")
+with (out / "reads.fa").open("w") as fh:
+    read_id = 0
+    for idx, mer in enumerate(kmers):
+        for _ in range(coverage[idx]):
+            fh.write(f">r{read_id}_k{idx}\n{mer}\n")
+            read_id += 1
+PY
+
+make -C "$repo_root" >/dev/null
+
+extract_locations() {
+    awk '/Found [0-9]+ variation locations/ { print $2; exit }' "$1"
+}
+
+for min_cov in 2 4; do
+    "$repo_root/ProGenFixer" \
+        -k 5 -a 5 -c "$min_cov" -n 1 --no-backfill \
+        -o "$tmpdir/out_c${min_cov}" \
+        "$tmpdir/ref.fa" "$tmpdir/reads.fa" \
+        >"$tmpdir/c${min_cov}.stdout" \
+        2>"$tmpdir/c${min_cov}.stderr"
+done
+
+count_c2="$(extract_locations "$tmpdir/c2.stderr")"
+count_c4="$(extract_locations "$tmpdir/c4.stderr")"
+
+if [[ "$count_c2" != "1" ]]; then
+    echo "expected -c 2 to find 1 variation location, got $count_c2" >&2
+    exit 1
+fi
+
+if [[ "$count_c4" != "2" ]]; then
+    echo "expected -c 4 to find 2 variation locations, got $count_c4" >&2
+    exit 1
+fi
+
+echo "min_cov region detection regression passed"


### PR DESCRIPTION
## Summary
- Decouple the -c low-coverage trigger from region-closing anchors, which now use the assembly coverage threshold.
- Track low-coverage runs and current k-mer array bounds to avoid artificial splitting and out-of-bounds extension.
- Document the clarified threshold semantics and add a regression test for min_cov behavior.

## Tests
- make clean && make
- tests/test_min_cov_region_detection.sh