### PR TITLE
Skip overlapping variation models

### DIFF
--- a/ProGenFixer.c
+++ b/ProGenFixer.c
@@ -592,17 +592,26 @@ static int record_variation(evaluation_t *eva, const char *chrom, int pos,
 {
     if (eva == NULL || chrom == NULL || ref == NULL || alt == NULL || type == NULL) return 0;
     if (pos <= 0) return 0;
+    size_t span_len = ref_len > 0 ? ref_len : 1;
+    if ((size_t)pos > (size_t)INT_MAX - span_len + 1) return 0;
+    int end = pos + (int)span_len - 1;
 
     for (int i = 0; i < eva->var_count; i++) {
         variation_t *old = &eva->variations[i];
         if (old->chrom == NULL || old->ref == NULL || old->alt == NULL) continue;
+        if (strcmp(old->chrom, chrom) != 0) continue;
         if (old->pos == pos &&
-            strcmp(old->chrom, chrom) == 0 &&
             strcmp(old->type, type) == 0 &&
             strlen(old->ref) == ref_len &&
             strlen(old->alt) == alt_len &&
             memcmp(old->ref, ref, ref_len) == 0 &&
             memcmp(old->alt, alt, alt_len) == 0) {
+            return 0;
+        }
+        size_t old_span_len = strlen(old->ref);
+        if (old_span_len == 0) old_span_len = 1;
+        int old_end = old->pos + (int)old_span_len - 1;
+        if (pos <= old_end && old->pos <= end) {
             return 0;
         }
     }

--- a/tests/test_apply_variations.sh
+++ b/tests/test_apply_variations.sh
@@ -35,6 +35,7 @@ int main(int argc, char **argv)
     FILE *fp = fopen(ref_path, "w");
     if (!fp) return 3;
     fprintf(fp, ">%s\\nAACCGGTT\\n", long_name);
+    fprintf(fp, ">overlap\\nAAAACCCCGGGGTTTT\\n");
     fprintf(fp, ">big\\n");
     write_repeat(fp, 'A', 1100);
     fprintf(fp, "TT\\n");
@@ -52,6 +53,8 @@ int main(int argc, char **argv)
 
     record_variation(&eva, long_name, 3, "C", 1, "T", 1, "SUB");
     record_variation(&eva, long_name, 3, "C", 1, "T", 1, "SUB");
+    record_variation(&eva, "overlap", 5, "CCCCGGGG", 8, "C", 1, "DEL");
+    record_variation(&eva, "overlap", 8, "CGGGG", 5, "", 0, "DEL");
 
     char *big_ref = malloc(1101);
     char *big_alt = malloc(1103);
@@ -104,6 +107,7 @@ if name is not None:
 
 long_name = "L" * 179
 assert records[long_name] == "AATCGGTT", records.get(long_name)
+assert records["overlap"] == "AAAACTTTT", records["overlap"]
 assert records["big"] == ("A" * 1100) + "CCTT", len(records["big"])
 PY
 


### PR DESCRIPTION
## Summary
- Reject same-contig variation records whose REF spans overlap an already queued model.
- Keep exact duplicate filtering, and extend apply_variations regression coverage with a nested deletion case.

## Diagnosis
For SRR1770413 with -c 2, two DEL models were emitted around 257899:
- 257899, REF length 777, ALT length 1
- 257908, REF length 776, ALT length 0

The second model is nested inside the first. Applying variants in descending coordinate order deleted the inner span first, so the outer span later failed REF validation and produced the reported mismatch.

## Tests
- make clean && make
- tests/test_apply_variations.sh
- tests/test_min_cov_region_detection.sh
- Full SRR1770413 -c 2 --fix run: no REF mismatch; iter1 applies 43 variants; 257899 vicinity keeps only the outer DEL.