### PR TITLE
Bump version to v1.1

### DIFF
--- a/ProGenFixer.c
+++ b/ProGenFixer.c
@@ -2341,7 +2341,7 @@ int main(int argc, char *argv[])
         }
         
         fprintf(vcf_fp, "##fileformat=VCFv4.5\n");
-        fprintf(vcf_fp, "##ProGenFixerVersion=v1.0\n");
+        fprintf(vcf_fp, "##ProGenFixerVersion=v1.1\n");
         fprintf(vcf_fp, "##ProGenFixerCommand=");
         for (int i = 0; i < argc; i++) {
             fprintf(vcf_fp, "%s%s", argv[i], (i == argc - 1) ? "" : " ");
@@ -2462,7 +2462,7 @@ int main(int argc, char *argv[])
 void usage(int k, int n_thread, int min_cov, int assem_min_cov, int insert_size, float error_rate, int max_assem_cov) { // Added max_assem_cov parameter
     fprintf(stderr, "\n");
     fprintf(stderr, "ProGenFixer: an ultra-fast and accurate tool for correcting prokaryotic genome sequences using a mapping-free algorithm\n");
-    fprintf(stderr, "Version v1.0  Author: Lifu Song songlf@tib.cas.cn\n");
+    fprintf(stderr, "Version v1.1  Author: Lifu Song songlf@tib.cas.cn\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Usage: ProGenFixer [options] Reference NGS_files -o output_prefix\n");
     fprintf(stderr, "       [Supporting formats: fq, fa, fq.gz, fa.gz]\n");

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ ProGenFixer outputs variants in VCF format (VCFv4.5 compatible). The VCF files i
 
 ```
 ##fileformat=VCFv4.5
-##ProGenFixerVersion=v1.0
+##ProGenFixerVersion=v1.1
 ##ProGenFixerCommand=[command line used]
 ##INFO=<ID=KMER_COV,Number=1,Type=Integer,Description="K-mer coverage of the variant path">
 ##INFO=<ID=VARTYPE,Number=1,Type=String,Description="Variant type (INS, DEL, SUB)">


### PR DESCRIPTION
## Summary
- update ProGenFixer runtime version text to v1.1
- update VCF ProGenFixerVersion header to v1.1
- update README VCF header example to v1.1

## Verification
- make
- verified -h output contains Version v1.1
- verified generated VCF contains ##ProGenFixerVersion=v1.1